### PR TITLE
Extending crop with aspect ratio maintained

### DIFF
--- a/degirum_tools/compound_models.py
+++ b/degirum_tools/compound_models.py
@@ -12,7 +12,12 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from .image_tools import detect_motion
 from typing import Union
+from enum import Enum
 
+class CropExtentOption(Enum):
+    ASPECT_RATIO_NO_ADJUSTMENT = 1
+    ASPECT_RATIO_ADJUSTMENT_BY_LONG_SIDE = 2
+    ASPECT_RATIO_ADJUSTMENT_BY_AREA = 3
 
 class ModelLike(ABC):
     """
@@ -209,7 +214,7 @@ class CroppingCompoundModel(CompoundModelBase):
     Restriction: first model should be of object detection type.
     """
 
-    def __init__(self, model1, model2, crop_extent=0, keep_aspect_ratio=False):
+    def __init__(self, model1, model2, crop_extent=0, crop_extent_option=CropExtentOption.ASPECT_RATIO_NO_ADJUSTMENT):
         """
         Constructor.
 
@@ -217,12 +222,29 @@ class CroppingCompoundModel(CompoundModelBase):
             model1: PySDK object detection model
             model2: PySDK classification model
             crop_extent: extent of cropping in percent of bbox size
-            keep_aspect_ratio: preserve model2's input aspect ratio when applying extending crop
+            crop_extent_option: method of applying extending crop to the input image for model2;
+                can be one of the following:
+                    - CropExtentOption.ASPECT_RATIO_NO_ADJUSTMENT: each dimension of the bounding box
+                      is extended by 'crop_extent'.
+                      
+                    - CropExtentOption.ASPECT_RATIO_ADJUSTMENT_BY_LONG_SIDE: the longer dimension of the
+                      bounding box is extended by 'crop_extent', and the other side is calculated as
+                      new_bbox_h * aspect_ratio (if the longer dimension is the height of the bounding box)
+                      or new_bbox_w / aspect_ratio (if the longer dimension is the width of the bounding box),
+                      aspect_ratio is defined as the ratio of model2's input width to model2's input height
+                      
+                    - CropExtentOption.ASPECT_RATIO_ADJUSTMENT_BY_AREA: the bounding box is extended by an
+                      area factor of ('crop_extent' * 0.01 + 1) ^ 2; the new height is determined from the
+                      desired area and aspect ratio, and is adjusted to be at least as long as the original
+                      bounding box height; the new width is calculated as new_bbox_h * aspect_ratio, where
+                      aspect_ratio is defined as the ratio of model2's input width to model2's input height,
+                      and then adjusted to be at least as long as the original bounding box width; the new
+                      height is then adjusted as new_bbox_w / aspect_ratio
         """
 
         super().__init__(model1, model2)
         self._crop_extent = crop_extent
-        self._keep_aspect_ratio = keep_aspect_ratio
+        self._crop_extent_option = crop_extent_option
 
     def queue_result1(self, result1):
         """
@@ -276,14 +298,33 @@ class CroppingCompoundModel(CompoundModelBase):
 
     def _adjust_bbox(self, bbox, image_size):
         """
-        Inflate bbox coordinates to crop extent and adjust to image size
+        Inflate bbox coordinates to crop extent according to chosen crop extent approach
+        and adjust to image size
 
         Args:
             bbox: bbox coordinates in [x1, y1, x2, y2] format
             image_size: image size in (width, height) format
         """
         bbox_w, bbox_h = bbox[2] - bbox[0], bbox[3] - bbox[1]
-        if self._keep_aspect_ratio:
+        
+        if self._crop_extent_option == CropExtentOption.ASPECT_RATIO_NO_ADJUSTMENT:
+            scale = self._crop_extent * 0.01 * 0.5
+            dx = bbox_w * scale
+            dy = bbox_h * scale
+            
+        elif self._crop_extent_option == CropExtentOption.ASPECT_RATIO_ADJUSTMENT_BY_LONG_SIDE:
+            scale = self._crop_extent * 0.01 + 1.0
+            aspect_ratio = self.model2.model_info.InputW[0] / self.model2.model_info.InputH[0]
+            if bbox_h > bbox_w:
+                new_bbox_h = bbox_h * scale
+                new_bbox_w = new_bbox_h * aspect_ratio
+            else:
+                new_bbox_w = bbox_w * scale
+                new_bbox_h = new_bbox_w / aspect_ratio
+            dx = (new_bbox_w - bbox_w) / 2
+            dy = (new_bbox_h - bbox_h) / 2
+            
+        elif self._crop_extent_option == CropExtentOption.ASPECT_RATIO_ADJUSTMENT_BY_AREA:
             expansion_factor = np.power(self._crop_extent * 0.01 + 1, 2)
             aspect_ratio = self.model2.model_info.InputW[0] / self.model2.model_info.InputH[0]
             new_bbox_h = np.sqrt(bbox_w * bbox_h * expansion_factor / aspect_ratio)
@@ -291,12 +332,9 @@ class CroppingCompoundModel(CompoundModelBase):
             new_bbox_w = new_bbox_h * aspect_ratio
             new_bbox_w = max(new_bbox_w, bbox_w)
             new_bbox_h = new_bbox_w / aspect_ratio
-            dx = max((new_bbox_w - bbox_w) / 2, 0)
-            dy = max((new_bbox_h - bbox_h) / 2, 0)
-        else:
-            scale = self._crop_extent * 0.01 * 0.5
-            dx = bbox_w * scale
-            dy = bbox_h * scale
+            dx = (new_bbox_w - bbox_w) / 2
+            dy = (new_bbox_h - bbox_h) / 2
+            
         maxval = [image_size[0], image_size[1], image_size[0], image_size[1]]
         adjust = [-dx, -dy, dx, dy]
         return [min(maxval[i], max(0, round(bbox[i] + adjust[i]))) for i in range(4)]
@@ -314,7 +352,7 @@ class CroppingAndClassifyingCompoundModel(CroppingCompoundModel):
     second model should be of classification type.
     """
 
-    def __init__(self, model1, model2, crop_extent=0, keep_aspect_ratio=False):
+    def __init__(self, model1, model2, crop_extent=0, crop_extent_option=CropExtentOption.ASPECT_RATIO_NO_ADJUSTMENT):
         """
         Constructor.
 
@@ -322,6 +360,24 @@ class CroppingAndClassifyingCompoundModel(CroppingCompoundModel):
             model1: PySDK object detection model
             model2: PySDK classification model
             crop_extent: extent of cropping in percent of bbox size
+            crop_extent_option: method of applying extending crop to the input image for model2;
+                can be one of the following:
+                    - CropExtentOption.ASPECT_RATIO_NO_ADJUSTMENT: each dimension of the bounding box
+                      is extended by 'crop_extent'.
+                      
+                    - CropExtentOption.ASPECT_RATIO_ADJUSTMENT_BY_LONG_SIDE: the longer dimension of the
+                      bounding box is extended by 'crop_extent', and the other side is calculated as
+                      new_bbox_h * aspect_ratio (if the longer dimension is the height of the bounding box)
+                      or new_bbox_w / aspect_ratio (if the longer dimension is the width of the bounding box),
+                      aspect_ratio is defined as the ratio of model2's input width to model2's input height
+                      
+                    - CropExtentOption.ASPECT_RATIO_ADJUSTMENT_BY_AREA: the bounding box is extended by an
+                      area factor of ('crop_extent' * 0.01 + 1) ^ 2; the new height is determined from the
+                      desired area and aspect ratio, and is adjusted to be at least as long as the original
+                      bounding box height; the new width is calculated as new_bbox_h * aspect_ratio, where
+                      aspect_ratio is defined as the ratio of model2's input width to model2's input height,
+                      and then adjusted to be at least as long as the original bounding box width; the new
+                      height is then adjusted as new_bbox_w / aspect_ratio
         """
 
         if model1.image_backend != model2.image_backend:
@@ -329,7 +385,7 @@ class CroppingAndClassifyingCompoundModel(CroppingCompoundModel):
                 f"Image backends of both models should be the same, but got {model1.image_backend} and {model2.image_backend}"
             )
 
-        super().__init__(model1, model2, crop_extent, keep_aspect_ratio)
+        super().__init__(model1, model2, crop_extent, crop_extent_option)
         self._current_result = None
 
     def transform_result2(self, result2):
@@ -404,7 +460,7 @@ class CroppingAndDetectingCompoundModel(CroppingCompoundModel):
     second model should be of object detection type.
     """
 
-    def __init__(self, model1, model2, *, crop_extent=0, add_model1_results=False, keep_aspect_ratio=False):
+    def __init__(self, model1, model2, *, crop_extent=0, add_model1_results=False, crop_extent_option=CropExtentOption.ASPECT_RATIO_NO_ADJUSTMENT):
         """
         Constructor.
 
@@ -413,6 +469,7 @@ class CroppingAndDetectingCompoundModel(CroppingCompoundModel):
             model2: PySDK object detection model
             crop_extent: extent of cropping in percent of bbox size
             add_model1_results: True to add detections of model1 to the combined result
+            keep_aspect_ratio: preserve model2's input aspect ratio when applying extending crop
         """
 
         if model1.image_backend != model2.image_backend:
@@ -420,7 +477,7 @@ class CroppingAndDetectingCompoundModel(CroppingCompoundModel):
                 f"Image backends of both models should be the same, but got {model1.image_backend} and {model2.image_backend}"
             )
 
-        super().__init__(model1, model2, crop_extent, keep_aspect_ratio)
+        super().__init__(model1, model2, crop_extent, crop_extent_option)
         self._current_result = None
         self._current_result1 = None
         self._add_model1_results = add_model1_results

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(Path(__file__).resolve().parent / "README.md", encoding="utf-8") as f:
 
 setup(
     name="degirum_tools",
-    version="0.5.1",
+    version="0.5.2",
     description="Tools for PySDK",
     author="DeGirum",
     license="",


### PR DESCRIPTION
A new feature is added to the CroppingCompoundModel's cropping method for the output bounding boxes of the first model in the pipeline. The user can set a flag to enable extending cropping to match the aspect ratio of the resulting bounding box to the aspect ratio of the second model's input.