### PR TITLE
add/fix video stream features

### DIFF
--- a/degirum_tools/inference_support.py
+++ b/degirum_tools/inference_support.py
@@ -179,6 +179,7 @@ def predict_stream(
     model: dg.model.Model,
     video_source_id: Union[int, str, Path, None],
     *,
+    fps: Optional[float] = None,
     analyzers: Union[ResultAnalyzerBase, List[ResultAnalyzerBase], None] = None,
 ):
     """Run a model on a video stream
@@ -201,7 +202,7 @@ def predict_stream(
     analyzing_postprocessor = _create_analyzing_postprocessor_class(analyzers)
 
     with open_video_stream(video_source_id) as stream:
-        for res in model.predict_batch(video_source(stream)):
+        for res in model.predict_batch(video_source(stream, fps=fps)):
             if analyzers is not None:
                 yield analyzing_postprocessor(result=res)
             else:
@@ -215,6 +216,7 @@ def annotate_video(
     *,
     show_progress: bool = True,
     visual_display: bool = True,
+    fps: Optional[float] = None,
     analyzers: Union[ResultAnalyzerBase, List[ResultAnalyzerBase], None] = None,
 ):
     """Annotate video stream by running a model and saving results to video file
@@ -253,16 +255,20 @@ def annotate_video(
         else:
             stream = stack.enter_context(open_video_stream(video_source_id))
 
-        w, h, fps = get_video_stream_properties(stream)
+        w, h, video_fps = get_video_stream_properties(stream)
+
+        # Overwrite the video stream's FPS if the fps argument is set.
+        if fps:
+            video_fps = fps
 
         writer = stack.enter_context(
-            open_video_writer(str(output_video_path), w, h, fps)
+            open_video_writer(str(output_video_path), w, h, video_fps)
         )
 
         if show_progress:
             progress = Progress(int(stream.get(cv2.CAP_PROP_FRAME_COUNT)))
 
-        for res in model.predict_batch(video_source(stream)):
+        for res in model.predict_batch(video_source(stream, fps=video_fps)):
             img = res.image_overlay
 
             for analyzer in analyzer_list:

--- a/degirum_tools/inference_support.py
+++ b/degirum_tools/inference_support.py
@@ -191,6 +191,8 @@ def predict_stream(
             - IP camera URL in the format "rtsp://<user>:<password>@<ip or hostname>",
             - local path or URL to mp4 video file,
             - YouTube video URL
+        fps - optional fps cap. If greater than the actual FPS, it will do nothing.
+           If less than the current fps, it will decimate frames accordingly.
         analyzers - optional analyzer or list of analyzers to be applied to model inference results
 
     Returns:
@@ -231,6 +233,8 @@ def annotate_video(
         - YouTube video URL
         show_progress - when True, show text progress indicator
         visual_display - when True, show interactive video display with annotated video stream
+        fps - optional fps cap. If greater than the actual FPS, it will do nothing.
+           If less than the current fps, it will decimate frames accordingly.
         analyzers - optional analyzer or list of analyzers to be applied to model inference results
     """
 

--- a/degirum_tools/inference_support.py
+++ b/degirum_tools/inference_support.py
@@ -203,10 +203,8 @@ def predict_stream(
 
     analyzing_postprocessor = _create_analyzing_postprocessor_class(analyzers)
 
-    decimate_frames = False if isinstance(video_source_id, int) else True
-
     with open_video_stream(video_source_id) as stream:
-        for res in model.predict_batch(video_source(stream, fps=fps, frame_decimate=decimate_frames)):
+        for res in model.predict_batch(video_source(stream, fps=fps)):
             if analyzers is not None:
                 yield analyzing_postprocessor(result=res)
             else:
@@ -274,9 +272,7 @@ def annotate_video(
         if show_progress:
             progress = Progress(int(stream.get(cv2.CAP_PROP_FRAME_COUNT)))
 
-        decimate_frames = False if isinstance(video_source_id, int) else True
-
-        for res in model.predict_batch(video_source(stream, fps=video_fps, frame_decimate=decimate_frames)):
+        for res in model.predict_batch(video_source(stream, fps=video_fps)):
             img = res.image_overlay
 
             for analyzer in analyzer_list:

--- a/degirum_tools/inference_support.py
+++ b/degirum_tools/inference_support.py
@@ -203,8 +203,10 @@ def predict_stream(
 
     analyzing_postprocessor = _create_analyzing_postprocessor_class(analyzers)
 
+    decimate_frames = False if isinstance(video_source_id, int) else True
+
     with open_video_stream(video_source_id) as stream:
-        for res in model.predict_batch(video_source(stream, fps=fps)):
+        for res in model.predict_batch(video_source(stream, fps=fps, frame_decimate=decimate_frames)):
             if analyzers is not None:
                 yield analyzing_postprocessor(result=res)
             else:
@@ -272,7 +274,9 @@ def annotate_video(
         if show_progress:
             progress = Progress(int(stream.get(cv2.CAP_PROP_FRAME_COUNT)))
 
-        for res in model.predict_batch(video_source(stream, fps=video_fps)):
+        decimate_frames = False if isinstance(video_source_id, int) else True
+
+        for res in model.predict_batch(video_source(stream, fps=video_fps, frame_decimate=decimate_frames)):
             img = res.image_overlay
 
             for analyzer in analyzer_list:

--- a/degirum_tools/video_support.py
+++ b/degirum_tools/video_support.py
@@ -120,8 +120,6 @@ def video_source(
     stream - video stream context manager object returned by open_video_stream()
     fps - optional fps cap. If greater than the actual FPS, it will do nothing.
        If less than the current fps, it will decimate frames accordingly.
-    frame_decimate - If fps is set, and frame decimation is True, frames are decimated
-       by frame count. If false, decimation occurs by time.
     Yields video frame captured from given video stream
     """
 

--- a/degirum_tools/video_support.py
+++ b/degirum_tools/video_support.py
@@ -202,7 +202,7 @@ class VideoWriter:
 
             # use ffmpeg-wrapped VideoWriter on other platforms;
             # reason: OpenCV VideoWriter does not support H264 on Linux
-            self._writer = ffmpegcv.VideoWriter(fname, codec=None, fps=fps)
+            self._writer = ffmpegcv.VideoWriter(fname, codec=None, fps=fps, resize=(w, h))
         else:
             # use OpenCV VideoWriter on Windows
             self._writer = cv2.VideoWriter(

--- a/degirum_tools/video_support.py
+++ b/degirum_tools/video_support.py
@@ -147,11 +147,12 @@ def video_source(
                 break
         if fps:
             curr_time = time.time()
+            elapsed_time = curr_time - prev_time
 
-            if curr_time - prev_time < minimum_elapsed_time:
+            if elapsed_time < minimum_elapsed_time:
                 continue
 
-            prev_time = curr_time
+            prev_time = curr_time - (elapsed_time - minimum_elapsed_time)
 
             yield frame
         else:

--- a/degirum_tools/video_support.py
+++ b/degirum_tools/video_support.py
@@ -141,7 +141,7 @@ class VideoWriter:
 
             # use ffmpeg-wrapped VideoWriter on other platforms;
             # reason: OpenCV VideoWriter does not support H264 on Linux
-            self._writer = ffmpegcv.VideoWriter(fname, None, fps, (w, h))
+            self._writer = ffmpegcv.VideoWriter(fname, codec=None, fps=fps)
         else:
             # use OpenCV VideoWriter on Windows
             self._writer = cv2.VideoWriter(


### PR DESCRIPTION
Fix ffmpegcv VideoWriter instantiation (new version changed function signature).

Add decimation to video_source, annotate_video, and predict_stream. It isn't "perfect", e.g. I set fps=30, I will get ~27 FPS. Is there a better way to do this? Seems like it will change based on the CPU load. 

Ignore DASH/HLS format youtube videos for lower resolution videos and resort to best format if a lower resolution "normal mp4" doesn't exist. We can probably get this to work but it seems too involved to be worth it. I tried to open the DASH manifest directly with FFMPEG (which supports dash demuxer) but YouTube refuses the request even with the same HTTP headers used to retrieve from pafy. 