### PR TITLE
Stack images

### DIFF
--- a/degirum_tools/ui_support.py
+++ b/degirum_tools/ui_support.py
@@ -206,7 +206,7 @@ def stack_images(
     labels: Optional[list] = None,
     font_color: tuple = (255, 255, 255),
 ) -> Union[np.ndarray, PIL.Image.Image]:
-    """ Stacks two images, either vertically or horizontally with the option two downscale
+    """ Stacks two images, either vertically or horizontally with the option to downscale
         the images and have labels in the bottom left corner. The two images must be the same
         size.
 
@@ -231,9 +231,6 @@ def stack_images(
         img1 = image1
         img2 = image2  # type: ignore[assignment]
 
-    if img1.shape != img2.shape:
-        raise Exception("Image shapes must be the same for stacking.")
-
     if downscale is not None:
         if downscale < 1.0:
             img1 = cv2.resize(img1,
@@ -244,14 +241,21 @@ def stack_images(
                               interpolation=cv2.INTER_AREA)
 
     h, w, c = img1.shape
-    img_dtype = img2.dtype
+    h2, w2, c = img2.shape
+    img_dtype = img1.dtype
 
     if dimension == 'horizontal':
-        stacked_img = np.zeros((h, w * 2, c), dtype=img_dtype)
+        if img1.shape[0] != img2.shape[0]:
+            raise Exception("Image heights must match for horizontal stacking.")
+
+        stacked_img = np.zeros((h, w + w2, c), dtype=img_dtype)
         stacked_img[:h, :w, :] = img1
         stacked_img[:h, w:, :] = img2
     elif dimension == 'vertical':
-        stacked_img = np.zeros((h * 2, w, c), dtype=img_dtype)
+        if img1.shape[1] != img2.shape[1]:
+            raise Exception("Image widths must match for vertical stacking.")
+
+        stacked_img = np.zeros((h + h2, w, c), dtype=img_dtype)
         stacked_img[:h, :w, :] = img1
         stacked_img[h:, :w, :] = img2
     else:

--- a/degirum_tools/ui_support.py
+++ b/degirum_tools/ui_support.py
@@ -208,7 +208,7 @@ def stack_images(
 ) -> Union[np.ndarray, PIL.Image.Image]:
     """ Stacks two images, either vertically or horizontally with the option to downscale
         the images and have labels in the bottom left corner. The two images must be the same
-        size.
+        size on the stacking dimension.
 
     Args:
         image1 - numpy array or PIL image

--- a/degirum_tools/ui_support.py
+++ b/degirum_tools/ui_support.py
@@ -150,8 +150,13 @@ def put_text(
         )
         x_adjustment = max_width if corner_position != CornerPosition.BOTTOM_LEFT else 0
         for li in lines:
-            li.x = max(0, li.x - x_adjustment)
-            li.y = max(0, li.y - y_adjustment)
+            li.x -= x_adjustment
+            li.y -= y_adjustment
+
+            if li.x < 0:
+                li.x += im_w
+            if li.y < 0:
+                li.y += im_h
 
     for li in lines:
         if bg_color is not None:

--- a/degirum_tools/ui_support.py
+++ b/degirum_tools/ui_support.py
@@ -11,7 +11,7 @@ import cv2, sys, os, time, PIL.Image, numpy as np, random, string
 from .environment import get_test_mode, in_colab, in_notebook, to_valid_filename
 from .image_tools import crop, luminance
 from dataclasses import dataclass
-from typing import Optional, Any, List
+from typing import Optional, Union, Any, List, Callable
 from enum import Enum
 from pathlib import Path
 
@@ -196,6 +196,103 @@ def put_text(
         )
 
     return image
+
+
+def stack_images(
+    image1: Union[np.ndarray, PIL.Image.Image],
+    image2: Union[np.ndarray, PIL.Image.Image],
+    dimension: str = 'horizontal',
+    downscale: Optional[float] = None,
+    labels: Optional[list] = None,
+    font_color: tuple = (255, 255, 255),
+) -> Union[np.ndarray, PIL.Image.Image]:
+    """ Stacks two images, either vertically or horizontally with the option two downscale
+        the images and have labels in the bottom left corner. The two images must be the same
+        size.
+
+    Args:
+        image1 - numpy array or PIL image
+        image2 - numpy array or PIL image
+        dimension: str - "horizontal" or "vertical", specifies dimension to stack
+        downscale: Optional[float] - scaling factor from 0.0-1/0 for the images
+        labels: Optional[list] - string labels for image1 and image2
+        font_color: tuple - font color in the form of a RGB tuple
+
+    Returns:
+        stacked image with optional resizing and labels
+    """
+    ret_type: Callable = np.array
+
+    if isinstance(image1, PIL.Image.Image):
+        img1 = np.array(image1)
+        img2 = np.array(image2)
+        ret_type = PIL.Image.fromarray
+    else:
+        img1 = image1
+        img2 = image2  # type: ignore[assignment]
+
+    if img1.shape != img2.shape:
+        raise Exception("Image shapes must be the same for stacking.")
+
+    if downscale is not None:
+        if downscale < 1.0:
+            img1 = cv2.resize(img1,
+                              dsize=None, fx=downscale, fy=downscale,
+                              interpolation=cv2.INTER_AREA)
+            img2 = cv2.resize(img2,
+                              dsize=None, fx=downscale, fy=downscale,
+                              interpolation=cv2.INTER_AREA)
+
+    h, w, c = img1.shape
+    img_dtype = img2.dtype
+
+    if dimension == 'horizontal':
+        stacked_img = np.zeros((h, w * 2, c), dtype=img_dtype)
+        stacked_img[:h, :w, :] = img1
+        stacked_img[:h, w:, :] = img2
+    elif dimension == 'vertical':
+        stacked_img = np.zeros((h * 2, w, c), dtype=img_dtype)
+        stacked_img[:h, :w, :] = img1
+        stacked_img[h:, :w, :] = img2
+    else:
+        raise Exception("Unsupported image stacking dimension.")
+
+    if isinstance(labels, list) and isinstance(labels[0], str):
+        if len(labels) != 2:
+            raise Exception('Must have two labels for stacked images.')
+
+        if dimension == 'horizontal':
+            stacked_img = put_text(
+                stacked_img,
+                labels[0],
+                (0, 0),
+                font_color=font_color,
+                corner_position=CornerPosition.BOTTOM_LEFT
+            )
+            stacked_img = put_text(
+                stacked_img,
+                labels[1],
+                (w, 0),
+                font_color=font_color,
+                corner_position=CornerPosition.BOTTOM_LEFT
+            )
+        else:
+            stacked_img = put_text(
+                stacked_img,
+                labels[0],
+                (0, h),
+                font_color=font_color,
+                corner_position=CornerPosition.BOTTOM_LEFT
+            )
+            stacked_img = put_text(
+                stacked_img,
+                labels[1],
+                (0, 0),
+                font_color=font_color,
+                corner_position=CornerPosition.BOTTOM_LEFT
+            )
+
+    return ret_type(stacked_img)
 
 
 class FPSMeter:

--- a/degirum_tools/zone_count.py
+++ b/degirum_tools/zone_count.py
@@ -39,6 +39,7 @@ from .math_support import AnchorPoint, get_anchor_coordinates
 
 Mat = type[np.ndarray[Any, np.dtype[Any]]]
 
+
 class _PolygonZone:
     """
     A class for defining a polygon-shaped zone within a frame for detecting objects.

--- a/degirum_tools/zone_count.py
+++ b/degirum_tools/zone_count.py
@@ -215,7 +215,7 @@ class ZoneCounter(ResultAnalyzerBase):
         # draw annotations
         for zi in range(len(self._polygons)):
             cv2.polylines(
-                image, self._polygons[zi].tolist(), True, line_color, result.overlay_line_width
+                image, [self._polygons[zi].tolist()], True, line_color, result.overlay_line_width
             )
 
             if self._per_class_display and self._class_list is not None:

--- a/degirum_tools/zone_count.py
+++ b/degirum_tools/zone_count.py
@@ -37,8 +37,6 @@ from .ui_support import put_text, color_complement, deduce_text_color
 from .result_analyzer_base import ResultAnalyzerBase
 from .math_support import AnchorPoint, get_anchor_coordinates
 
-Mat = type[np.ndarray[Any, np.dtype[Any]]]
-
 
 class _PolygonZone:
     """
@@ -64,7 +62,7 @@ class _PolygonZone:
 
         self.width, self.height = frame_resolution_wh
         self.mask = np.zeros((self.height + 1, self.width + 1))
-        cv2.fillPoly(self.mask, [polygon.astype(int)], color=[1])
+        cv2.fillPoly(self.mask, polygon.astype(int).tolist(), color=[1])
 
     def trigger(self, bboxes: np.ndarray) -> np.ndarray:
         """

--- a/degirum_tools/zone_count.py
+++ b/degirum_tools/zone_count.py
@@ -215,7 +215,7 @@ class ZoneCounter(ResultAnalyzerBase):
         # draw annotations
         for zi in range(len(self._polygons)):
             cv2.polylines(
-                image, [self._polygons[zi]], True, line_color, result.overlay_line_width
+                image, self._polygons[zi].tolist(), True, line_color, result.overlay_line_width
             )
 
             if self._per_class_display and self._class_list is not None:

--- a/degirum_tools/zone_count.py
+++ b/degirum_tools/zone_count.py
@@ -37,6 +37,7 @@ from .ui_support import put_text, color_complement, deduce_text_color
 from .result_analyzer_base import ResultAnalyzerBase
 from .math_support import AnchorPoint, get_anchor_coordinates
 
+Mat = type[np.ndarray[Any, np.dtype[Any]]]
 
 class _PolygonZone:
     """


### PR DESCRIPTION
Fix cornerposition logic in put_text. Now corner_xy works relative to the cornerposition.

Add stack_images, useful for comparing two images, e.g. original image vs depth map or original image vs style transfer. Right now the label functionality is fixed. Would it be worth it to give the user more control on the label text (position, size, etc)? I picked bottom_left because currently FPS is default set to top_left.