### PR TITLE
Compound model predict_batch fixes

### DIFF
--- a/degirum_tools/compound_models.py
+++ b/degirum_tools/compound_models.py
@@ -156,7 +156,10 @@ class CompoundModelBase(ModelLike):
         def result2_apply_final_steps(result2, transformed_result2):
 
             # restore original frame info to support nested compound models
-            transformed_result2._frame_info = transformed_result2.info.original_info
+            if isinstance(transformed_result2, FrameInfo):
+                transformed_result2._frame_info = transformed_result2.info.original_info
+            else:
+                transformed_result2._frame_info = transformed_result2.info
 
             # apply analyzers if any
             if self._analyzers:

--- a/degirum_tools/compound_models.py
+++ b/degirum_tools/compound_models.py
@@ -156,7 +156,7 @@ class CompoundModelBase(ModelLike):
         def result2_apply_final_steps(result2, transformed_result2):
 
             # restore original frame info to support nested compound models
-            if isinstance(transformed_result2, FrameInfo):
+            if isinstance(transformed_result2.info, FrameInfo):
                 transformed_result2._frame_info = transformed_result2.info.original_info
             else:
                 transformed_result2._frame_info = transformed_result2.info

--- a/degirum_tools/compound_models.py
+++ b/degirum_tools/compound_models.py
@@ -546,7 +546,7 @@ class CroppingAndDetectingCompoundModel(CroppingCompoundModel):
                     use_iou=self._nms_options.use_iou,
                     box_select=self._nms_options.box_select,
                 )
-            
+
             if isinstance(self._current_result.info, FrameInfo):
                 self._current_result._frame_info = self._current_result.info.original_info
 

--- a/degirum_tools/compound_models.py
+++ b/degirum_tools/compound_models.py
@@ -546,6 +546,10 @@ class CroppingAndDetectingCompoundModel(CroppingCompoundModel):
                     use_iou=self._nms_options.use_iou,
                     box_select=self._nms_options.box_select,
                 )
+            
+            if isinstance(self._current_result.info, FrameInfo):
+                self._current_result._frame_info = self._current_result.info.original_info
+
             return self._current_result
         return None
 

--- a/degirum_tools/compound_models.py
+++ b/degirum_tools/compound_models.py
@@ -156,7 +156,7 @@ class CompoundModelBase(ModelLike):
         def result2_apply_final_steps(result2, transformed_result2):
 
             # restore original frame info to support nested compound models
-            transformed_result2._frame_info = result2.info.original_info
+            transformed_result2._frame_info = transformed_result2.info.original_info
 
             # apply analyzers if any
             if self._analyzers:
@@ -590,7 +590,7 @@ class CroppingAndDetectingCompoundModel(CroppingCompoundModel):
 
         else:
             # new frame comes: return combined result of previous frame
-            ret = self._finalize_current_result(result1)
+            ret = self._finalize_current_result(self._current_result1)
             self._current_result = result2
             self._current_result1 = result1
 

--- a/degirum_tools/tile_compound_models.py
+++ b/degirum_tools/tile_compound_models.py
@@ -1,19 +1,17 @@
 import copy
 from typing import List, MutableSequence, Optional, Sequence, Tuple, Union
 
-import cv2
-import numpy as np
+import cv2, numpy as np, degirum as dg
 
-import degirum as dg
-from degirum_tools import (
-    CroppingAndDetectingCompoundModel,
+from .math_support import nms, edge_box_fusion
+from .compound_models import (
+    FrameInfo,
     CropExtentOptions,
     ModelLike,
     NmsOptions,
     MotionDetectOptions,
-    detect_motion,
-)
-from degirum_tools.math_support import nms, edge_box_fusion
+    CroppingAndDetectingCompoundModel,
+    detect_motion)
 
 
 class _TileInfo:
@@ -694,6 +692,10 @@ class BoxFusionTileModel(_EdgeMixin, TileModel):
                     use_iou=self._nms_options.use_iou,
                     box_select=self._nms_options.box_select,
                 )
+
+            if isinstance(self._current_result.info, FrameInfo):
+                self._current_result._frame_info = self._current_result.info.original_info
+
             return self._current_result
         return None
 

--- a/degirum_tools/tile_compound_models.py
+++ b/degirum_tools/tile_compound_models.py
@@ -568,7 +568,7 @@ class LocalGlobalTileModel(TileModel):
 
         else:
             # new frame comes: return combined result of previous frame
-            ret = self._finalize_current_result(result1)
+            ret = self._finalize_current_result(self._current_result1)
             self._current_result = result2
             self._current_result1 = result1
 
@@ -770,7 +770,7 @@ class BoxFusionTileModel(_EdgeMixin, TileModel):
 
         else:
             # new frame comes: return combined result of previous frame
-            ret = self._finalize_current_result(result1)
+            ret = self._finalize_current_result(self._current_result1)
             self._current_result = result2
             self._current_result1 = result1
 
@@ -906,7 +906,7 @@ class BoxFusionLocalGlobalTileModel(BoxFusionTileModel):
 
         else:
             # new frame comes: return combined result of previous frame
-            ret = self._finalize_current_result(result1)
+            ret = self._finalize_current_result(self._current_result1)
             self._current_result = result2
             self._current_result1 = result1
 


### PR DESCRIPTION
bug: When using predict_batch, the results for each image is off by one if you take the DetectionResults.info (a path to the image) as the truth. The final result in the batch also does not restore the original_info (returns a FrameInfo object).

This PR fixes these issues.
