### PR TITLE
Fixed potential hangs with notifier analyzers

### DIFF
--- a/degirum_tools/inference_support.py
+++ b/degirum_tools/inference_support.py
@@ -238,6 +238,8 @@ def attach_analyzers(
             if model._custom_postprocessor is not None and hasattr(
                 model._custom_postprocessor, "_custom_postprocessor_saved"
             ):
+                for analyzer in model._custom_postprocessor._analyzers:
+                    analyzer.finalize()
                 # restore the original custom postprocessor
                 model._custom_postprocessor = (
                     model._custom_postprocessor._custom_postprocessor_saved

--- a/degirum_tools/notifier.py
+++ b/degirum_tools/notifier.py
@@ -386,7 +386,7 @@ class NotificationServer:
                 if job is not None:
                     pending_jobs[job.id] = job
 
-                # Upon queue empty exception, queue is active is never set to false, resulting in 
+                # Upon queue empty exception, queue is active is never set to false, resulting in
                 # (if not pending jobs) to keep resetting loop infinitely
                 if job is None:  # poison pill received
                     queue_is_active = False

--- a/degirum_tools/notifier.py
+++ b/degirum_tools/notifier.py
@@ -376,20 +376,16 @@ class NotificationServer:
             # process queue
             if queue_is_active:
                 try:
-                    # Setting timeout to None causes infinite wait when pending jobs is empty
                     job = job_queue.get(
-                        timeout=queue_poll_interval_s if pending_jobs else 10
+                        timeout=queue_poll_interval_s if pending_jobs else None
                     )
+                    if job is None:  # poison pill received
+                        queue_is_active = False
                 except queue.Empty:
                     job = None
 
                 if job is not None:
                     pending_jobs[job.id] = job
-
-                # Upon queue empty exception, queue is active is never set to false, resulting in
-                # (if not pending jobs) to keep resetting loop infinitely
-                if job is None:  # poison pill received
-                    queue_is_active = False
 
             if not pending_jobs:
                 continue


### PR DESCRIPTION
When trying to run these examples for dg_tools using notifiers: https://github.com/DeGirum/dg_tools_notifier_examples, I encountered a bug that caused my program to hang forever once the video was done being annotated. The video would properly close, but the terminal would stay at the 100% mark of the progress bar. 