### PR TITLE
Vladk/streaming

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
     types: [opened, edited, reopen, synchronize, ready_for_review]
   workflow_dispatch:
+
 jobs:
   lint:
     name: Linters/Type Checkers
@@ -29,6 +30,7 @@ jobs:
         run: python3 -m flake8 .
       - name: Run mypy
         run: python3 -m mypy
+
   test:
     name: Unit Tests
     strategy:
@@ -49,6 +51,7 @@ jobs:
           pip install -e '.[testing,notifications]'
           sudo apt update
           sudo apt install ffmpeg
+          test/install-mediamtx.sh
       - name: Run pytest (with coverage)
         run: python3 -m coverage run -m pytest -s -v test/
         env:

--- a/degirum_tools/streams_gizmos.py
+++ b/degirum_tools/streams_gizmos.py
@@ -242,9 +242,9 @@ class VideoSaverGizmo(Gizmo):
 
 
 class VideoStreamerGizmo(Gizmo):
-    """OpenCV-based video saving gizmo.
+    """Video streaming gizmo.
 
-    Streams incoming frames to RTSP stream.
+    Streams incoming frames to RTSP stream using ffmpeg.
     `MediaServer` must be running to accept the stream.
     """
 

--- a/degirum_tools/streams_gizmos.py
+++ b/degirum_tools/streams_gizmos.py
@@ -252,7 +252,7 @@ class VideoStreamerGizmo(Gizmo):
         self,
         rtsp_url: str,
         *,
-        fps: int = 30,
+        fps: float = 30,
         show_ai_overlay: bool = False,
         stream_depth: int = 10,
         allow_drop: bool = False,
@@ -263,7 +263,7 @@ class VideoStreamerGizmo(Gizmo):
             rtsp_url (str): RTSP URL to stream to (e.g., 'rtsp://user:password@hostname:port/stream').
                             Typically you use `MediaServer` class to start media server and
                             then use its RTSP URL like `rtsp://localhost:8554/mystream`
-            fps (int, optional): Frames per second for the stream. Defaults to 30.
+            fps (float, optional): Frames per second for the stream. Defaults to 30.
             show_ai_overlay (bool, optional): If True, overlay AI inference results on frames before saving (when available). Defaults to False.
             stream_depth (int, optional): Depth of the input frame queue. Defaults to 10.
             allow_drop (bool, optional): If True, allow dropping frames if the input queue is full. Defaults to False.

--- a/degirum_tools/streams_gizmos.py
+++ b/degirum_tools/streams_gizmos.py
@@ -10,9 +10,9 @@ from typing import Optional, List, Union
 from contextlib import ExitStack
 from .streams_base import Stream, StreamData, StreamMeta, Gizmo
 from .environment import get_test_mode
-from .video_support import open_video_stream, open_video_writer
+from .video_support import open_video_stream, open_video_writer, VideoStreamer
 from .ui_support import Display
-from .image_tools import crop_image, resize_image, image_size, to_opencv
+from .image_tools import crop_image, resize_image, image_size, ImageType
 from .result_analyzer_base import image_overlay_substitute, clone_result
 from .crop_extent import CropExtentOptions, extend_bbox
 from .notifier import EventNotifier
@@ -20,12 +20,12 @@ from .event_detector import EventDetector
 from .environment import get_token
 
 # predefined meta tags
-tag_video = "dgt_video"            # tag for video source data
-tag_resize = "dgt_resize"          # tag for resizer result
-tag_inference = "dgt_inference"    # tag for inference result
+tag_video = "dgt_video"  # tag for video source data
+tag_resize = "dgt_resize"  # tag for resizer result
+tag_inference = "dgt_inference"  # tag for inference result
 tag_preprocess = "dgt_preprocess"  # tag for preprocessor result
-tag_crop = "dgt_crop"              # tag for cropping result
-tag_analyzer = "dgt_analyzer"      # tag for analyzer result
+tag_crop = "dgt_crop"  # tag for cropping result
+tag_analyzer = "dgt_analyzer"  # tag for analyzer result
 
 
 class VideoSourceGizmo(Gizmo):
@@ -35,12 +35,12 @@ class VideoSourceGizmo(Gizmo):
     """
 
     # meta keys for video frame information
-    key_frame_width = "frame_width"    # frame width
+    key_frame_width = "frame_width"  # frame width
     key_frame_height = "frame_height"  # frame height
-    key_fps = "fps"                    # stream frame rate
-    key_frame_count = "frame_count"    # total frame count (if known)
-    key_frame_id = "frame_id"          # frame index (sequence number)
-    key_timestamp = "timestamp"        # frame timestamp
+    key_fps = "fps"  # stream frame rate
+    key_frame_count = "frame_count"  # total frame count (if known)
+    key_frame_id = "frame_id"  # frame index (sequence number)
+    key_timestamp = "timestamp"  # frame timestamp
 
     def __init__(self, video_source=None, *, stop_composition_on_end: bool = False):
         """Constructor.
@@ -191,7 +191,7 @@ class VideoDisplayGizmo(Gizmo):
 
 
 class VideoSaverGizmo(Gizmo):
-    """OpenCV-based video saving gizmo.
+    """Video saving gizmo.
 
     Writes incoming frames to an output video file.
     """
@@ -221,13 +221,15 @@ class VideoSaverGizmo(Gizmo):
 
         Reads frames from the input stream and writes them to the output file until the stream is exhausted or aborted.
         """
-        def get_img(data: StreamData) -> np.ndarray:
+
+        def get_img(data: StreamData) -> ImageType:
             frame = data.data
             if self._show_ai_overlay:
                 inference_meta = data.meta.find_last(tag_inference)
                 if inference_meta:
                     frame = inference_meta.image_overlay
-            return to_opencv(frame)
+            return frame
+
         img = get_img(self.get_input(0).get())
         w, h = image_size(img)
         with open_video_writer(self._filename, w, h) as writer:
@@ -239,6 +241,64 @@ class VideoSaverGizmo(Gizmo):
                 writer.write(get_img(data))
 
 
+class VideoStreamerGizmo(Gizmo):
+    """OpenCV-based video saving gizmo.
+
+    Streams incoming frames to RTSP stream.
+    `MediaServer` must be running to accept the stream.
+    """
+
+    def __init__(
+        self,
+        rtsp_url: str,
+        *,
+        fps: int = 30,
+        show_ai_overlay: bool = False,
+        stream_depth: int = 10,
+        allow_drop: bool = False,
+    ):
+        """Constructor.
+
+        Args:
+            rtsp_url (str): RTSP URL to stream to (e.g., 'rtsp://user:password@hostname:port/stream').
+                            Typically you use `MediaServer` class to start media server and
+                            then use its RTSP URL like `rtsp://localhost:8554/mystream`
+            fps (int, optional): Frames per second for the stream. Defaults to 30.
+            show_ai_overlay (bool, optional): If True, overlay AI inference results on frames before saving (when available). Defaults to False.
+            stream_depth (int, optional): Depth of the input frame queue. Defaults to 10.
+            allow_drop (bool, optional): If True, allow dropping frames if the input queue is full. Defaults to False.
+        """
+        super().__init__([(stream_depth, allow_drop)])
+        self._rtsp_url = rtsp_url
+        self._fps = fps
+        self._show_ai_overlay = show_ai_overlay
+
+    def run(self):
+        """Run the video saving loop.
+
+        Reads frames from the input stream and writes them to the output file until the stream is exhausted or aborted.
+        """
+
+        def get_img(data: StreamData) -> ImageType:
+            frame = data.data
+            if self._show_ai_overlay:
+                inference_meta = data.meta.find_last(tag_inference)
+                if inference_meta:
+                    frame = inference_meta.image_overlay
+            return frame
+
+        img = get_img(self.get_input(0).get())
+        w, h = image_size(img)
+        pix_fmt = "bgr24" if isinstance(img, np.ndarray) else "rgb24"
+        with VideoStreamer(self._rtsp_url, w, h, fps=self._fps, pix_fmt=pix_fmt) as streamer:
+            self.result_cnt += 1
+            streamer.write(img)
+            for data in self.get_input(0):
+                if self._abort:
+                    break
+                streamer.write(get_img(data))
+
+
 class ResizingGizmo(Gizmo):
     """OpenCV-based image resizing/padding gizmo.
 
@@ -246,9 +306,9 @@ class ResizingGizmo(Gizmo):
     """
 
     # meta keys for output image parameters
-    key_frame_width = "frame_width"      # frame width after resize
-    key_frame_height = "frame_height"    # frame height after resize
-    key_pad_method = "pad_method"        # padding method used
+    key_frame_width = "frame_width"  # frame width after resize
+    key_frame_height = "frame_height"  # frame height after resize
+    key_pad_method = "pad_method"  # padding method used
     key_resize_method = "resize_method"  # resampling method used
 
     def __init__(
@@ -361,6 +421,7 @@ class AiGizmoBase(Gizmo):
 
         Internally feeds data from the input stream(s) into the model and yields results, invoking `on_result` for each inference result.
         """
+
         def source():
             has_data = True
             while has_data:
@@ -445,9 +506,9 @@ class AiObjectDetectionCroppingGizmo(Gizmo):
 
     # meta keys for crop result information
     key_original_result = "original_result"  # original detection result object
-    key_cropped_result = "cropped_result"    # detection result entry for the crop
-    key_cropped_index = "cropped_index"      # index of the object in original results
-    key_is_last_crop = "is_last_crop"        # flag indicating last crop in frame
+    key_cropped_result = "cropped_result"  # detection result entry for the crop
+    key_cropped_index = "cropped_index"  # index of the object in original results
+    key_is_last_crop = "is_last_crop"  # flag indicating last crop in frame
 
     def __init__(
         self,
@@ -689,7 +750,9 @@ class CropCombiningGizmo(Gizmo):
                     combined_meta = None  # reset for next frame
                     break
 
-    def _adjust_results(self, orig_result, bbox_idx: int, cropped_results: list) -> list:
+    def _adjust_results(
+        self, orig_result, bbox_idx: int, cropped_results: list
+    ) -> list:
         """Adjust inference results from a crop to the original image's coordinate space.
 
         This converts the coordinates (e.g., bounding boxes, landmarks) of inference results obtained on a cropped image back to the coordinate system of the original image.
@@ -728,6 +791,7 @@ class CropCombiningGizmo(Gizmo):
         Returns:
             (dg.postprocessor.InferenceResults): A cloned inference result with a deep-copied results list.
         """
+
         def _overlay_extra_results(res):
             """Produce an image overlay including all extra results."""
             overlay_image = result._orig_image_overlay_extra_results
@@ -847,7 +911,6 @@ class AiPreprocessGizmo(Gizmo):
         stream_depth: int = 10,
         allow_drop: bool = False,
     ):
-
         """Constructor.
 
         Args:
@@ -959,13 +1022,13 @@ class SinkGizmo(Gizmo):
 
     This gizmo does not send data further down the pipeline. Instead, it stores all incoming results so they can be retrieved (for example, by iterating over the gizmo's output in the main thread).
     """
+
     def __init__(
         self,
         *,
         stream_depth: int = 10,
         allow_drop: bool = False,
     ):
-
         """Constructor.
 
         Args:

--- a/degirum_tools/video_support.py
+++ b/degirum_tools/video_support.py
@@ -48,7 +48,11 @@ Configuration Options:
     - Output file naming and paths
 """
 
+import platform
+import shutil
+import subprocess
 import time, os, threading, cv2, urllib, copy, json, uuid
+import ffmpeg
 import numpy as np
 from collections import deque
 from contextlib import contextmanager
@@ -712,3 +716,174 @@ class ClipSaver:
                 thread.join()
                 nthreads += 1
         return nthreads
+
+
+class MediaServer:
+    """Manages the MediaMTX media server as a subprocess.
+
+    Starts MediaMTX using a provided config file path. If no config path is given,
+    it runs from the MediaMTX binary's directory.
+
+    MediaMTX binary must be installed and available in the system path.
+    Refer to https://github.com/bluenviron/mediamtx for installation instructions.
+    """
+
+    def __init__(self, *, config_path: Optional[str] = None, verbose: bool = False):
+        """Initializes and starts the server.
+
+        Args:
+            config_path: Path to an existing MediaMTX YAML config file.
+                         If not provided, runs with config file from binary directory.
+            verbose: If True, shows media server output in the console.
+        """
+        self._verbose: bool = verbose
+        self._process: Optional[subprocess.Popen] = None
+        self._config_path: Optional[str] = config_path
+        self._binary: str = (
+            "mediamtx.exe" if platform.system() == "Windows" else "mediamtx"
+        )
+
+        binary_path = shutil.which(self._binary)
+        if not binary_path:
+            raise FileNotFoundError(
+                f"Cannot find {self._binary} in PATH. MediaMTX binary must be installed and available in the system path."
+            )
+
+        # Determine working directory
+        self._working_dir: str = os.path.dirname(
+            os.path.abspath(config_path if config_path else binary_path)
+        )
+        self._start()
+
+    def _start(self):
+        """Starts the media server subprocess."""
+        cmd = [self._binary]
+        if self._config_path:
+            cmd.append(self._config_path)
+
+        stdout = None if self._verbose else subprocess.DEVNULL
+        stderr = None if self._verbose else subprocess.DEVNULL
+
+        self._process = subprocess.Popen(
+            cmd, cwd=self._working_dir, stdout=stdout, stderr=stderr
+        )
+
+    def stop(self):
+        """Stops the media server process."""
+        if self._process and self._process.poll() is None:
+            self._process.terminate()
+            try:
+                self._process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+        self._process = None
+
+    def __del__(self):
+        """Destructor to ensure the media server is stopped."""
+        self.stop()
+
+    def __enter__(self):
+        """Enables use with context manager."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Stops server when context exits."""
+        self.stop()
+
+
+class VideoStreamer:
+    """Streams video frames to an RTSP server using FFmpeg.
+    This class uses FFmpeg to stream video frames to an RTSP server.
+    FFmpeg must be installed and available in the system path.
+    """
+
+    def __init__(
+        self,
+        rtsp_url: str,
+        width: int,
+        height: int,
+        *,
+        fps: int = 30,
+        pix_fmt="bgr24",
+        verbose: bool = False,
+    ):
+        """Initializes the video streamer.
+
+        Args:
+            rtsp_url (str): RTSP URL to stream to (e.g., 'rtsp://user:password@hostname:port/stream').
+                            Typically you use `MediaServer` class to start media server and
+                            then use its RTSP URL like `rtsp://localhost:8554/mystream`
+            width (int): Width of the video frames in pixels.
+            height (int): Height of the video frames in pixels.
+            fps (int, optional): Frames per second for the stream. Defaults to 30.
+            pix_fmt (str, optional): Pixel format for the input frames. Defaults to 'bgr24'. Can be 'rgb24'.
+            verbose (bool, optional): If True, shows FFmpeg output in the console. Defaults to False.
+        """
+        self._width = width
+        self._height = height
+
+        self._process = (
+            ffmpeg.input(
+                "pipe:0",
+                format="rawvideo",
+                pix_fmt="bgr24",
+                s=f"{width}x{height}",
+                framerate=fps,
+            )
+            .output(
+                rtsp_url,
+                format="rtsp",
+                pix_fmt="yuv420p",
+                vcodec="libx264",
+                preset="ultrafast",
+                tune="zerolatency",
+                rtsp_transport="tcp",
+                fflags="nobuffer",
+                max_delay=0,
+            )
+            .global_args("-loglevel", "info" if verbose else "quiet")
+            .run_async(pipe_stdin=True, quiet=not verbose)
+        )
+
+    def write(self, img: ImageType):
+        """Writes a frame to the RTSP stream.
+        Args:
+            img (ImageType): Frame to write. Can be:
+                - OpenCV image (np.ndarray)
+                - PIL Image
+
+            Pixel format must match the one specified in the constructor (default is 'bgr24').
+        """
+
+        im_sz = image_size(img)
+
+        if (self._width, self._height) != im_sz:
+            img = resize_image(img, self._width, self._height)
+
+        try:
+            self._process.stdin.write(img.tobytes())
+        except (BrokenPipeError, IOError):
+            self.stop()
+
+    def stop(self):
+        """Stops the streamer process."""
+        if self._process:
+            if self._process.stdin:
+                try:
+                    self._process.stdin.close()
+                except Exception:
+                    pass
+            self._process.wait()
+            self._process = None
+
+    def __del__(self):
+        """Destructor to ensure the streamer is stopped."""
+        self.stop()
+
+    def __enter__(self):
+        """Enables use with context manager."""
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Stops streamer when context exits."""
+        self.stop()

--- a/degirum_tools/video_support.py
+++ b/degirum_tools/video_support.py
@@ -803,7 +803,7 @@ class VideoStreamer:
         width: int,
         height: int,
         *,
-        fps: int = 30,
+        fps: float = 30.0,
         pix_fmt="bgr24",
         verbose: bool = False,
     ):
@@ -815,7 +815,7 @@ class VideoStreamer:
                             then use its RTSP URL like `rtsp://localhost:8554/mystream`
             width (int): Width of the video frames in pixels.
             height (int): Height of the video frames in pixels.
-            fps (int, optional): Frames per second for the stream. Defaults to 30.
+            fps (float, optional): Frames per second for the stream. Defaults to 30.
             pix_fmt (str, optional): Pixel format for the input frames. Defaults to 'bgr24'. Can be 'rgb24'.
             verbose (bool, optional): If True, shows FFmpeg output in the console. Defaults to False.
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ youtube-dl==2020.12.2
 pycocotools
 pyyaml
 ffmpegcv>=0.3.15;platform_system!='Windows'
+ffmpeg-python
 typing-extensions
 jsonschema
 apprise

--- a/test/install-mediamtx.sh
+++ b/test/install-mediamtx.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Script to install MediaMTX from GitHub releases
+
+# Set MediaMTX version
+MTX_VERSION="v1.12.3"
+
+# Determine OS and architecture
+OS="$(uname | tr '[:upper:]' '[:lower:]')"  # 'linux' or 'darwin'
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64) ARCH="amd64" ;;
+  aarch64 | arm64) ARCH="arm64" ;;
+  *) echo "Unsupported architecture: $ARCH" && exit 1 ;;
+esac
+
+# Construct download URL
+FILENAME="mediamtx_${MTX_VERSION}_${OS}_${ARCH}.tar.gz"
+URL="https://github.com/bluenviron/mediamtx/releases/download/${MTX_VERSION}/${FILENAME}"
+
+echo "Downloading $URL"
+if ! curl -fsSL -o "$FILENAME" "$URL"; then
+  echo "❌ Failed to download MediaMTX from $URL"
+  exit 1
+fi
+
+TMPDIR="$(mktemp -d)"
+
+# Extract into temp dir
+tar -xzf "$FILENAME" -C "$TMPDIR"
+
+# Copy all extracted files to /usr/local/bin
+sudo cp -a "$TMPDIR"/* /usr/local/bin/
+sudo chmod +x /usr/local/bin/mediamtx
+
+# Clean up
+rm -rf "$TMPDIR" "$FILENAME"

--- a/test/test_video_streamer.py
+++ b/test/test_video_streamer.py
@@ -13,8 +13,6 @@ def test_video_streamer():
     Test for EventNotifier analyzer
     """
 
-    return
-
     import degirum_tools
     import numpy as np
     import time
@@ -48,7 +46,8 @@ def test_video_streamer():
                 assert np.all(data.data[:, :, 2] > 250)
                 if cnt >= 10:  # Limit to 10 frames for the test
                     break
-            self.composition.stop()
+            if self.composition:
+                self.composition.stop()
 
     url = "rtsp://localhost:8554/mystream"
     src = TestSourceGizmo()

--- a/test/test_video_streamer.py
+++ b/test/test_video_streamer.py
@@ -10,7 +10,7 @@
 
 def test_video_streamer():
     """
-    Test for EventNotifier analyzer
+    Test for VideoStreamerGizmo gizmo and MediaServer class
     """
 
     import degirum_tools

--- a/test/test_video_streamer.py
+++ b/test/test_video_streamer.py
@@ -1,0 +1,70 @@
+#
+# test_video_streamer.py: unit tests for video streaming functionality
+#
+# Copyright DeGirum Corporation 2025
+# All rights reserved
+#
+# Implements unit tests to test media server and video streaming functionality
+#
+
+
+def test_video_streamer():
+    """
+    Test for EventNotifier analyzer
+    """
+
+    return
+
+    import degirum_tools
+    import numpy as np
+    import time
+    from degirum_tools import streams
+
+    w = h = 100
+    fps = 30.0
+
+    class TestSourceGizmo(streams.Gizmo):
+        def run(self):
+            frame = np.zeros((h, w, 3), dtype=np.uint8)
+            frame[:, :, 2] = 255  # Set red channel to max
+            while not self._abort:
+                self.send_result(streams.StreamData(frame))
+                time.sleep(1 / fps)
+
+    class TestSinkGizmo(streams.Gizmo):
+
+        def __init__(self):
+            super().__init__([(0, False)])
+
+        def run(self):
+            cnt = 0
+            for data in self.get_input(0):
+                if self._abort:
+                    break
+                assert data.data.shape == (h, w, 3)
+                cnt += 1
+                assert np.all(data.data[:, :, 0] == 0)
+                assert np.all(data.data[:, :, 1] == 0)
+                assert np.all(data.data[:, :, 2] > 250)
+                if cnt >= 10:  # Limit to 10 frames for the test
+                    break
+            self.composition.stop()
+
+    url = "rtsp://localhost:8554/mystream"
+    src = TestSourceGizmo()
+    dst = streams.VideoStreamerGizmo(url, fps=fps)
+    rcv = streams.VideoSourceGizmo(url)
+    chk = TestSinkGizmo()
+
+    with degirum_tools.MediaServer():
+
+        # start streaming of red frames to RTSP server
+        src_composition = streams.Composition(src >> dst)
+        src_composition.start(wait=False)
+
+        time.sleep(1)  # Allow some time for the stream to start
+
+        # receive and check frames from RTSP server
+        rcv_composition = streams.Composition(rcv >> chk)
+        rcv_composition.start()
+        src_composition.stop()


### PR DESCRIPTION
Adds end-to-end video streaming support via MediaMTX, including a new server wrapper, streamer classes, a test, and CI integration.

- Introduce MediaServer and VideoStreamer in video_support.py
- Add VideoStreamerGizmo in streams_gizmos.py
- Provide an installer script for MediaMTX and integrate it into the GitHub Actions workflow
- New unit test for streaming red frames through RTSP