### PR TITLE
CroppingAndDetectingCompoundModel improvements

### DIFF
--- a/degirum_tools/_version.py
+++ b/degirum_tools/_version.py
@@ -6,5 +6,5 @@
 #
 
 # >>> increment version here vvv
-__version_info__ = ("0", "17", "0")
+__version_info__ = ("0", "18", "0")
 __version__ = ".".join(__version_info__)

--- a/degirum_tools/compound_models.py
+++ b/degirum_tools/compound_models.py
@@ -743,7 +743,7 @@ class CroppingAndDetectingCompoundModel(CroppingCompoundModel):
         4. Combines the results of the second model from all cropped regions, mapping coords back to the original image.
 
     Optionally, you can add model1 detections to the final result and/or apply NMS.
-    
+
     When model1 results are added, each detection from model2 will have a `crop_index` field, indicating which bounding box from model1 it corresponds to.
 
     Restriction:


### PR DESCRIPTION
CroppingAndDetectingCompoundModel: when model1 results are added (add_model1_results=True), each detection from model2 will have a `crop_index` field, indicating which bounding box from model1 it corresponds to.