### PR TITLE
Updated docstrings for cleaner mkdocs output

### DIFF
--- a/degirum_tools/event_detector.py
+++ b/degirum_tools/event_detector.py
@@ -220,7 +220,7 @@ def ZoneCount(result, params):
             aggregation (str): Aggregation function to apply across zones. One of 'sum', 'max', 'min', 'mean', 'std'. Defaults to 'sum'.
 
     Returns:
-        Union[int, float]: Total count of matching objects in the selected zone(s).
+        count (int | float): Total count of matching objects in the selected zone(s).
 
     Raises:
         AttributeError: If `result.zone_counts` is missing (no ZoneCounter applied upstream).

--- a/degirum_tools/inference_support.py
+++ b/degirum_tools/inference_support.py
@@ -120,7 +120,7 @@ import numpy as np
 import degirum as dg  # import DeGirum PySDK
 from contextlib import ExitStack
 from pathlib import Path
-from typing import Union, List, Optional
+from typing import Union, List, Optional, Iterator
 from dataclasses import dataclass
 from .compound_models import CompoundModelBase
 from .video_support import (
@@ -252,7 +252,7 @@ def predict_stream(
     *,
     fps: Optional[float] = None,
     analyzers: Union[ResultAnalyzerBase, List[ResultAnalyzerBase], None] = None,
-):
+) -> Iterator["dg.postprocessor.InferenceResults"]:
     """
     Run a PySDK model on a live or file-based video source, yielding inference results.
 
@@ -278,9 +278,8 @@ def predict_stream(
             One or more analyzers to apply to each inference result. If None, no additional
             analysis or annotation is performed beyond the model's standard postprocessing.
 
-    Returns:
-        Union[InferenceResults, AnalyzingPostprocessor]:
-            The inference result for each processed frame. If analyzers are present,
+    Yields:
+        InferenceResults: The inference result for each processed frame. If analyzers are present,
             the result object is wrapped to allow custom annotation in its `.image_overlay`.
 
     Example:

--- a/degirum_tools/line_count.py
+++ b/degirum_tools/line_count.py
@@ -652,7 +652,7 @@ class LineCounter(ResultAnalyzerBase):
             line (list or np.ndarray): Two endpoints of a line [x1, y1, x2, y2].
 
         Returns:
-            np.ndarray: Vector representing the direction of the line (x2 - x1, y2 - y1).
+            vector (np.ndarray): Direction vector of the line `(x2 - x1, y2 - y1)`.
         """
         return np.array([line[2] - line[0], line[3] - line[1]])
 

--- a/degirum_tools/object_selector.py
+++ b/degirum_tools/object_selector.py
@@ -151,7 +151,7 @@ class ObjectSelector(ResultAnalyzerBase):
         self._show_overlay = show_overlay
         self._annotation_color = annotation_color
 
-    def analyze(self, result):
+    def analyze(self, result) -> None:
         """
         Select the top-K objects based on the configured strategy, updating the result.
 
@@ -162,7 +162,7 @@ class ObjectSelector(ResultAnalyzerBase):
             result (InferenceResults): Model result with detection information.
 
         Returns:
-            None: The result object is modified in-place.
+            None: Modifies `result` in place; does not return a value.
         """
 
         if self._selection_strategy == ObjectSelectionStrategies.CUSTOM_METRIC:


### PR DESCRIPTION
Format for some returns was incorrect, resulting in empty columns when read by MkDocs.

predict_stream() is now documented with Yields rather than Returns.