### PR TITLE
Added application/x-rtp,media=video caps filter before decodebin

### DIFF
--- a/degirum_tools/tools/gst_support.py
+++ b/degirum_tools/tools/gst_support.py
@@ -194,11 +194,14 @@ def build_gst_pipeline(source):
     # 3. if source is str and starts with rtsp
     elif isinstance(source, str) and source.lower().startswith("rtsp://"):
         logger_get().info(f"Building RTSP pipeline for: {source}")
-        # Use decodebin for automatic format handling
+        # application/x-rtp,media=video selects only the video RTP pad from rtspsrc,
+        # preventing decodebin from receiving the audio stream and emitting an
+        # unlinked audio pad that would propagate a not-linked error upstream.
         return (
             f'rtspsrc location="{source}" latency=0 protocols=tcp ! '
+            f'application/x-rtp,media=video ! '
             f'decodebin ! videoconvert ! videoscale ! '
-            f'appsink name=sink'
+            f'video/x-raw,format={format} ! appsink name=sink'
         )
 
     # ==================== FILE SOURCE ====================

--- a/degirum_tools/tools/video_support.py
+++ b/degirum_tools/tools/video_support.py
@@ -132,10 +132,15 @@ class VideoCaptureGst:
             raise Exception(f"Invalid GStreamer pipeline (no appsink): {pipeline_str}")
 
         self._appsink.set_property("emit-signals", True)
+        # Live sources (RTSP/cameras) need sync=False to avoid blocking the
+        # PAUSED→PLAYING transition while waiting for a clock reference.
+        self._appsink.set_property("sync", False)
+        self._appsink.set_property("drop", True)
+        self._appsink.set_property("max-buffers", 5)
         self._pipeline.set_state(Gst.State.PLAYING)
 
-        # Check if the pipeline transitions to the PLAYING state
-        state_change_result = self._pipeline.get_state(5 * Gst.SECOND)
+        # RTSP connections need more time to negotiate and start streaming.
+        state_change_result = self._pipeline.get_state(15 * Gst.SECOND)
         if state_change_result[1] != Gst.State.PLAYING:
             raise Exception(f"GStreamer pipeline failed to start: {pipeline_str}")
 


### PR DESCRIPTION
gst_support.py — RTSP pipeline:                                                                        
  Added application/x-rtp,media=video caps filter before decodebin to select only the video RTP pad,     
  preventing the audio stream from reaching decodebin and causing a not-linked error.                    
                  
video_support.py — VideoCaptureGst.__init__:                                                           
- sync=False — prevents appsink from blocking on clock sync for live sources
- drop=True + max-buffers=5 — prevents appsink queue from stalling the pipeline                        
- Timeout bumped from 5s → 15s for RTSP negotiation 